### PR TITLE
Remove emails from alerts

### DIFF
--- a/vars/notify.groovy
+++ b/vars/notify.groovy
@@ -104,25 +104,10 @@ def call(String channel, Boolean alertEveryone = false) {
 
   if (env.GIT_BRANCH == 'master' && alertEveryone == true) {
     if (buildStatus == 'RECOVERED') {
-      emailext (
-          to: 'tech+jenkins@futurelearn.com',
-          subject: mailSubject,
-          body: mailBody,
-        )
       slackSend (channel: '#tech', attachments: attachments)
     } else if (buildStatus == 'REGRESSION') {
-      emailext (
-          to: 'tech+jenkins@futurelearn.com',
-          subject: mailSubject,
-          body: mailBody,
-        )
       slackSend (channel: '#tech', attachments: attachments)
     } else if (buildStatus == 'FAILURE') {
-      emailext (
-          to: 'tech+jenkins@futurelearn.com',
-          subject: mailSubject,
-          body: mailBody,
-        )
       slackSend (channel: '#tech', attachments: attachments)
     }
   }

--- a/vars/notify.groovy
+++ b/vars/notify.groovy
@@ -103,11 +103,7 @@ def call(String channel, Boolean alertEveryone = false) {
   slackSend (channel: channel, attachments: attachments)
 
   if (env.GIT_BRANCH == 'master' && alertEveryone == true) {
-    if (buildStatus == 'RECOVERED') {
-      slackSend (channel: '#tech', attachments: attachments)
-    } else if (buildStatus == 'REGRESSION') {
-      slackSend (channel: '#tech', attachments: attachments)
-    } else if (buildStatus == 'FAILURE') {
+    if (buildStatus == 'RECOVERED' || buildStatus == 'REGRESSION' || buildStatus == 'FAILURE') {
       slackSend (channel: '#tech', attachments: attachments)
     }
   }


### PR DESCRIPTION
We've decided email is an antiquated way to be notified about something, so remove them from the alerts.

Currently this will mean we'll only be notified via Slack, but we intend to add Datadog monitoring to let us know when the master branch is failing.